### PR TITLE
Changed LIBERTY_VERSION

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
 #can optionally delete the apt-get update files to save on image size at this point
 
 # Install WebSphere Liberty
-ENV LIBERTY_VERSION 16.0.0_2
+ENV LIBERTY_VERSION 17.0.0.2
 ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
-RUN LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
+RUN LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
     && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \
     && rm /tmp/wlp.zip


### PR DESCRIPTION
The newest LIBERTY_VERSION is 17.0.0.2 /3.
Error would occour because wget want to take version 16.0.0_2 from https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml.

But as you can see in this link, Major version 16 is not availible on this side.

Best Regards,
Noah